### PR TITLE
Update LESS to fix Dark theme incompatibility

### DIFF
--- a/less/forum/extension.less
+++ b/less/forum/extension.less
@@ -177,6 +177,7 @@ button, input, optgroup, select, textarea {
 }
 .dropdown-menu.iconpicker-container {
     padding: 0;
+    background-color: #fff;
 }
 .open>.dropdown-menu {
     display: block;
@@ -197,7 +198,6 @@ button, input, optgroup, select, textarea {
     font-size: 14px;
     text-align: left;
     list-style: none;
-    background-color: #fff;
     -webkit-background-clip: padding-box;
     background-clip: padding-box;
     border: 1px solid #ccc;


### PR DESCRIPTION
Background for dropdown menus was being set to white across the board, which makes legibility a problem on the dark themes. Moving the styling from the general .dropdown-menu to .dropdown-menu.iconpicker-container should fix.
